### PR TITLE
Return errors on first entry of WalkDir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,23 @@ rust:
 - nightly
 matrix:
   include:
-  - env: RUSTFMT
-    rust: 1.25.0  # `stable`: Locking down for consistent behavior
+  - name: check rustfmt
+    rust: 1.38.0  # `stable`: Locking down for consistent behavior
     install:
-      - rustup component add rustfmt-preview
+      - rustup component add rustfmt
     script:
-      - cargo fmt -- --write-mode=diff
-  - env: RUSTFLAGS="-D warnings"
-    rust: 1.25.0  # `stable`: Locking down for consistent behavior
-    install:
+      - cargo fmt --all -- --check
+  - name: check with -D warnings
+    env: RUSTFLAGS="-D warnings"
+    rust: 1.38.0  # `stable`: Locking down for consistent behavior
     script:
     - cargo check --tests --all-features
-  - env: CLIPPY_VERSION="0.0.179"
-    rust: nightly-2018-01-12
+  - name: check clippy
+    rust: 1.38.0  # `stable`: Locking down for consistent behavior
     install:
-      - travis_wait cargo install clippy --version $CLIPPY_VERSION || echo "clippy already installed"
+      - rustup component add clippy
     script:
-      - cargo clippy --all-features -- -D clippy
+      - cargo clippy --all --all-features -- -D warnings
 
 install:
 - rustc -Vv

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@
 
 extern crate walkdir;
 
+use std::cmp::Ordering;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
-use std::cmp::Ordering;
 
 use walkdir::{DirEntry, WalkDir};
 
@@ -45,7 +45,8 @@ pub fn is_different<A: AsRef<Path>, B: AsRef<Path>>(a_base: A, b_base: B) -> Res
         let a = a?;
         let b = b?;
 
-        if a.depth() != b.depth() || a.file_type() != b.file_type()
+        if a.depth() != b.depth()
+            || a.file_type() != b.file_type()
             || a.file_name() != b.file_name()
             || (a.file_type().is_file() && read_to_vec(a.path())? != read_to_vec(b.path())?)
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ pub enum Error {
 /// assert!(dir_diff::is_different("dir/a", "dir/b").unwrap());
 /// ```
 pub fn is_different<A: AsRef<Path>, B: AsRef<Path>>(a_base: A, b_base: B) -> Result<bool, Error> {
-    let mut a_walker = walk_dir(a_base);
-    let mut b_walker = walk_dir(b_base);
+    let mut a_walker = walk_dir(a_base)?;
+    let mut b_walker = walk_dir(b_base)?;
 
     for (a, b) in (&mut a_walker).zip(&mut b_walker) {
         let a = a?;
@@ -53,14 +53,16 @@ pub fn is_different<A: AsRef<Path>, B: AsRef<Path>>(a_base: A, b_base: B) -> Res
         }
     }
 
-    Ok(!a_walker.next().is_none() || !b_walker.next().is_none())
+    Ok(a_walker.next().is_some() || b_walker.next().is_some())
 }
 
-fn walk_dir<P: AsRef<Path>>(path: P) -> std::iter::Skip<walkdir::IntoIter> {
-    WalkDir::new(path)
-        .sort_by(compare_by_file_name)
-        .into_iter()
-        .skip(1)
+fn walk_dir<P: AsRef<Path>>(path: P) -> Result<walkdir::IntoIter, std::io::Error> {
+    let mut walkdir = WalkDir::new(path).sort_by(compare_by_file_name).into_iter();
+    if let Some(Err(e)) = walkdir.next() {
+        Err(e.into())
+    } else {
+        Ok(walkdir)
+    }
 }
 
 fn compare_by_file_name(a: &DirEntry, b: &DirEntry) -> Ordering {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -35,6 +35,24 @@ fn oneempty() {
 }
 
 #[test]
+#[should_panic]
+fn firstmissing() {
+    assert!(dir_diff::is_different("does_not_exist", "tests/easy/good/dir1").unwrap());
+}
+
+#[test]
+#[should_panic]
+fn secondmissing() {
+    assert!(dir_diff::is_different("tests/easy/good/dir1", "does_not_exist").unwrap());
+}
+
+#[test]
+#[should_panic]
+fn bothmissing() {
+    assert!(dir_diff::is_different("does_not_exist", "also_does_not_exist").unwrap());
+}
+
+#[test]
 fn reflexive() {
     assert!(dir_diff::is_different("tests/reflexive/dir1", "tests/reflexive/dir2").unwrap());
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,8 +1,8 @@
 extern crate dir_diff;
 
-use std::path::Path;
 use std::fs::create_dir;
 use std::io::ErrorKind;
+use std::path::Path;
 
 #[test]
 fn easy_good() {


### PR DESCRIPTION
The first entry of WalkDir is being skipped - the problem with this is that the first entry is where WalkDir can report that the directory for comparison doesn't exist. The current code will return `false` for the following cases:

    dir_diff::is_different("dir_that_exists", "dir_that_does_not_exist");
    dir_diff::is_different("dir_that_does_not_exist", "also_does_not_exist");

This is obviously not ideal since the directory not existing is probably not what the user intended.

This commit fixes up the issue by checking the first entry returned from WalkDir for error instead of skipping it. This causes `is_different` to return an error if either or both directories don't actually exist.

- [x] Tests created for any new feature or regression tests for bugfixes.
- [x] `cargo test` succeeds
- [x] `cargo +nightly clippy` succeeds
